### PR TITLE
Fix database name typo in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ LOG_LEVEL=debug
 DB_CONNECTION=sqlite
 # DB_HOST=127.0.0.1
 # DB_PORT=3306
-# DB_DATABASE=task_managment_pro
+# DB_DATABASE=task_management_pro
 # DB_USERNAME=root
 # DB_PASSWORD=
 


### PR DESCRIPTION
## Summary
- fix the typo `task_managment_pro` to `task_management_pro` in the example database name

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6845817b80d48327a9b59209d9d4d85f